### PR TITLE
fixed misalignment in constraints 7b, 9a, and 9b

### DIFF
--- a/src/constraints/start-up-and-shut-down-lower-bound.jl
+++ b/src/constraints/start-up-and-shut-down-lower-bound.jl
@@ -13,8 +13,8 @@ function add_start_up_and_shut_down_lower_bound_constraints!(
     constraints,
 )
     let table_name = :start_up_lower_bound, cons = constraints[table_name]
-        start_up = variables[:start_up].container
-        units_on = variables[:units_on].container
+        units_on = cons.expressions[:units_on]
+        start_up = cons.expressions[:start_up]
 
         attach_constraint!(
             model,
@@ -37,8 +37,8 @@ function add_start_up_and_shut_down_lower_bound_constraints!(
     end
 
     let table_name = :shut_down_lower_bound, cons = constraints[table_name]
-        shut_down = variables[:shut_down].container
-        units_on = variables[:units_on].container
+        shut_down = cons.expressions[:shut_down]
+        units_on = cons.expressions[:units_on]
 
         attach_constraint!(
             model,

--- a/src/constraints/start-up-upper-bound.jl
+++ b/src/constraints/start-up-upper-bound.jl
@@ -12,7 +12,13 @@ function add_start_up_upper_bound_constraints!(
     expressions,
     constraints,
 )
-    let table_name = :start_up_upper_bound, cons = constraints[:start_up_upper_bound]
+    let table_name = :start_up_upper_bound,
+        cons = constraints[:start_up_upper_bound],
+        start_up_vars = variables[:start_up].container,
+        units_on_vars = variables[:units_on].container
+
+        indices = _append_units_on_and_start_up_variable_ids(connection, table_name)
+
         attach_constraint!(
             model,
             cons,
@@ -20,11 +26,35 @@ function add_start_up_upper_bound_constraints!(
             [
                 @constraint(
                     model,
-                    start_up <= units_on,
+                    start_up_vars[row.start_up_id] <= units_on_vars[row.units_on_id],
                     base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-                ) for (row, start_up, units_on) in
-                zip(cons.indices, variables[:start_up].container, variables[:units_on].container)
+                ) for row in indices
             ],
         )
     end
+end
+
+function _append_units_on_and_start_up_variable_ids(connection, table_name)
+    return DuckDB.query(
+        connection,
+        "SELECT
+            cons.*,
+            var_units_on.id as units_on_id,
+            var_start_up.id as start_up_id
+        FROM cons_$table_name AS cons
+        LEFT JOIN asset
+            ON cons.asset = asset.asset
+        LEFT JOIN var_units_on
+            ON var_units_on.asset = cons.asset
+            AND var_units_on.year = cons.year
+            AND var_units_on.rep_period = cons.rep_period
+            AND var_units_on.time_block_start = cons.time_block_start
+        LEFT JOIN var_start_up
+            ON var_start_up.asset = cons.asset
+            AND var_start_up.year = cons.year
+            AND var_start_up.rep_period = cons.rep_period
+            AND var_start_up.time_block_start = cons.time_block_start
+        ORDER BY cons.id
+        ",
+    )
 end

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -615,6 +615,8 @@ function add_expressions_to_constraints!(connection, variables, constraints)
         :sd_ramp_vars_flow_upper_bound,
         :su_sd_ramp_vars_flow_with_high_uptime,
         :su_sd_eq_units_on_diff,
+        :start_up_lower_bound,
+        :shut_down_lower_bound,
     )
         @timeit to "attach units_on expression to $table_name" attach_expression_on_constraints_grouping_variables!(
             connection,


### PR DESCRIPTION
Fixed misalignment of SU/SD and units_on variables in constraints 7b, 9a, and 9b. In 7b I did it with an SQL query to add the SU/UC variable IDs to the constraint indices, and for 9a and 9b I used the intersection.jl file to add the variables as expressions.