### PR TITLE
Misalignment fixes with sql

### DIFF
--- a/src/constraints/minimum-up-and-down-time.jl
+++ b/src/constraints/minimum-up-and-down-time.jl
@@ -6,7 +6,11 @@ export add_minimum_up_time_constraints!, add_minimum_down_time_constraints!
 Adds the minimum up time constraints to the model.
 """
 function add_minimum_up_time_constraints!(connection, model, variables, expressions, constraints)
-    let table_name = :minimum_up_time, cons = constraints[:minimum_up_time]
+    let table_name = :minimum_up_time,
+        cons = constraints[:minimum_up_time],
+        units_on = variables[:units_on].container,
+        indices = _append_variable_ids(connection, table_name, ["units_on"])
+
         asset_year_rep_period_dict = Dict()
         for row in cons.indices
             key = "$(row.asset),$(row.year),$(row.rep_period)"
@@ -17,16 +21,10 @@ function add_minimum_up_time_constraints!(connection, model, variables, expressi
                     row.asset,
                     row.year,
                     row.rep_period,
+                    "start_up",
                 )
             end
         end
-
-        start_up_container, units_on_container = _get_correct_su_sd_and_units_on_variables(
-            cons.indices,
-            variables[:start_up].indices,
-            variables[:start_up].container,
-            variables[:units_on].container,
-        )
 
         attach_constraint!(
             model,
@@ -37,12 +35,11 @@ function add_minimum_up_time_constraints!(connection, model, variables, expressi
                     model,
                     _sum_min_up_blocks(
                         asset_year_rep_period_dict["$(row.asset),$(row.year),$(row.rep_period)"],
-                        start_up_container,
+                        variables[:start_up].container,
                         row.time_block_start,
-                    ) <= units_on,
+                    ) <= units_on[row.units_on_id],
                     base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-                ) for (row, start_up, units_on) in
-                zip(cons.indices, start_up_container, units_on_container)
+                ) for row in indices
             ],
         )
     end
@@ -58,46 +55,37 @@ function _sum_min_up_blocks(sum_rows, start_ups, start_of_curr_constraint)
             start_of_this <=
             start_of_curr_constraint
         )
-            sum = sum + start_ups[single_row.id]
+            sum = sum + start_ups[single_row.start_up_id]
         end
     end
     return sum
 end
 
-function _get_correct_su_sd_and_units_on_variables(
-    cons_indices,
-    susd_indices,
-    susd_vars,
-    units_on_vars,
+function _get_indices_for_sum(
+    connection,
+    table_name,
+    curr_asset,
+    curr_year,
+    curr_rep_period,
+    variable_name,
 )
-    susd_container = []
-    units_on_container = []
-    unique_assets = Set{String}()
+    variable_table_name = "var_" * variable_name
 
-    for row in cons_indices
-        push!(unique_assets, row.asset)
-    end
-
-    for (i, su, uo) in zip(susd_indices, susd_vars, units_on_vars)
-        if i.asset in unique_assets
-            push!(susd_container, su)
-            push!(units_on_container, uo)
-        end
-    end
-
-    return susd_container, units_on_container
-end
-
-function _get_indices_for_sum(connection, table_name, curr_asset, curr_year, curr_rep_period)
     return DuckDB.query(
         connection,
         "SELECT
             cons.*,
             asset.minimum_up_time,
-            asset.minimum_down_time
+            asset.minimum_down_time,
+            $variable_table_name.id as $(variable_name)_id,
         FROM cons_$table_name AS cons
         LEFT JOIN asset
             ON cons.asset = asset.asset
+        LEFT JOIN $variable_table_name
+            ON $variable_table_name.asset = cons.asset
+            AND $variable_table_name.year = cons.year
+            AND $variable_table_name.rep_period = cons.rep_period
+            AND $variable_table_name.time_block_start = cons.time_block_start
         WHERE cons.asset = '$curr_asset' AND cons.year = $curr_year AND cons.rep_period = $curr_rep_period
         ORDER BY cons.id
         ",
@@ -111,7 +99,7 @@ Adds the minimum down time constraints to the model.
 """
 function add_minimum_down_time_constraints!(connection, model, variables, expressions, constraints)
     #Minimum down time with simple investment strategy
-    let table_name = :minimum_down_time_simple_investment,
+    let table_name = :minimum_down_time_simple_investment, units_on = variables[:units_on].container
         cons = constraints[:minimum_down_time_simple_investment]
 
         asset_year_rep_period_dict = Dict()
@@ -124,6 +112,7 @@ function add_minimum_down_time_constraints!(connection, model, variables, expres
                     row.asset,
                     row.year,
                     row.rep_period,
+                    "shut_down",
                 )
             end
         end
@@ -132,13 +121,6 @@ function add_minimum_down_time_constraints!(connection, model, variables, expres
             expressions[:available_asset_units_simple_method].expressions[:assets]
 
         indices = _append_available_units_data_simple(connection, table_name)
-
-        shutdown_container, units_on_container = _get_correct_su_sd_and_units_on_variables(
-            cons.indices,
-            variables[:shut_down].indices,
-            variables[:shut_down].container,
-            variables[:units_on].container,
-        )
 
         attach_constraint!(
             model,
@@ -149,18 +131,19 @@ function add_minimum_down_time_constraints!(connection, model, variables, expres
                     model,
                     _sum_min_down_blocks(
                         asset_year_rep_period_dict["$(row.asset),$(row.year),$(row.rep_period)"],
-                        shutdown_container,
+                        variables[:shut_down].container,
                         row.time_block_start,
-                    ) <= expr_avail_simple_method[row.avail_id] - units_on,
+                    ) <= expr_avail_simple_method[row.avail_id] - units_on[row.units_on_id],
                     base_name = "minimum_down_time_simple_investment[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-                ) for
-                (row, shut_down, units_on) in zip(indices, shutdown_container, units_on_container)
+                ) for row in indices
             ],
         )
     end
 
     #Minimum down time with compact investment strategy
     let table_name = :minimum_down_time_compact_investment,
+        units_on = variables[:units_on].container
+
         cons = constraints[:minimum_down_time_compact_investment]
 
         asset_year_rep_period_dict = Dict()
@@ -173,6 +156,7 @@ function add_minimum_down_time_constraints!(connection, model, variables, expres
                     row.asset,
                     row.year,
                     row.rep_period,
+                    "shut_down",
                 )
             end
         end
@@ -181,13 +165,6 @@ function add_minimum_down_time_constraints!(connection, model, variables, expres
             expressions[:available_asset_units_compact_method].expressions[:assets]
 
         indices = _append_available_units_data_compact(connection, table_name)
-
-        shutdown_container, units_on_container = _get_correct_su_sd_and_units_on_variables(
-            cons.indices,
-            variables[:shut_down].indices,
-            variables[:shut_down].container,
-            variables[:units_on].container,
-        )
 
         attach_constraint!(
             model,
@@ -198,14 +175,13 @@ function add_minimum_down_time_constraints!(connection, model, variables, expres
                     model,
                     _sum_min_down_blocks(
                         asset_year_rep_period_dict["$(row.asset),$(row.year),$(row.rep_period)"],
-                        shutdown_container,
+                        variables[:shut_down].container,
                         row.time_block_start,
                     ) <=
                     sum(expr_avail_compact_method[avail_id] for avail_id in row.avail_indices) -
-                    units_on,
+                    units_on[row.units_on_id],
                     base_name = "minimum_down_time_compact_investment[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
-                ) for
-                (row, shut_down, units_on) in zip(indices, shutdown_container, units_on_container)
+                ) for row in indices
             ],
         )
     end
@@ -233,12 +209,18 @@ function _append_available_units_data_simple(connection, table_name)
         "SELECT
             cons.*,
             expr_avail.id AS avail_id,
+            var_units_on.id as units_on_id
         FROM cons_$table_name AS cons
         LEFT JOIN expr_available_asset_units_simple_method AS expr_avail
             ON cons.asset = expr_avail.asset
             AND cons.year = expr_avail.milestone_year
         LEFT JOIN asset
             ON cons.asset = asset.asset
+        LEFT JOIN var_units_on
+            ON var_units_on.asset = cons.asset
+            AND var_units_on.year = cons.year
+            AND var_units_on.rep_period = cons.rep_period
+            AND var_units_on.time_block_start = cons.time_block_start
         WHERE asset.investment_method in ('simple', 'none')
         ORDER BY cons.id
         ",
@@ -256,12 +238,18 @@ function _append_available_units_data_compact(connection, table_name)
             ANY_VALUE(cons.time_block_start) AS time_block_start,
             ANY_VALUE(cons.time_block_end) AS time_block_end,
             ARRAY_AGG(expr_avail.id) AS avail_indices,
+            ANY_VALUE(var_units_on.id) as units_on_id
         FROM cons_$table_name AS cons
         LEFT JOIN expr_available_asset_units_compact_method AS expr_avail
             ON cons.asset = expr_avail.asset
             AND cons.year = expr_avail.milestone_year
         LEFT JOIN asset
             ON cons.asset = asset.asset
+        LEFT JOIN var_units_on
+            ON var_units_on.asset = cons.asset
+            AND var_units_on.year = cons.year
+            AND var_units_on.rep_period = cons.rep_period
+            AND var_units_on.time_block_start = cons.time_block_start
         WHERE asset.investment_method = 'compact'
         GROUP BY cons.id
         ORDER BY cons.id

--- a/src/constraints/start-up-and-shut-down-lower-bound.jl
+++ b/src/constraints/start-up-and-shut-down-lower-bound.jl
@@ -13,8 +13,12 @@ function add_start_up_and_shut_down_lower_bound_constraints!(
     constraints,
 )
     let table_name = :start_up_lower_bound, cons = constraints[table_name]
-        units_on = cons.expressions[:units_on]
-        start_up = cons.expressions[:start_up]
+        units_on = variables[:units_on].container
+        start_up = variables[:start_up].container
+
+        indices = _append_variable_ids(connection, table_name, ["units_on", "start_up"])
+
+        print(indices)
 
         attach_constraint!(
             model,
@@ -27,18 +31,21 @@ function add_start_up_and_shut_down_lower_bound_constraints!(
                     else
                         @constraint(
                             model,
-                            units_on[row.id] - units_on[row.id-1] <= start_up[row.id],
+                            units_on[row.units_on_id] - units_on[row.units_on_id-1] <=
+                            start_up[row.start_up_id],
                             base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
                         )
                     end
-                end for row in cons.indices
+                end for row in indices
             ],
         )
     end
 
     let table_name = :shut_down_lower_bound, cons = constraints[table_name]
-        shut_down = cons.expressions[:shut_down]
-        units_on = cons.expressions[:units_on]
+        units_on = variables[:units_on].container
+        shut_down = variables[:shut_down].container
+
+        indices = _append_variable_ids(connection, table_name, ["units_on", "shut_down"])
 
         attach_constraint!(
             model,
@@ -51,11 +58,12 @@ function add_start_up_and_shut_down_lower_bound_constraints!(
                     else
                         @constraint(
                             model,
-                            units_on[row.id-1] - units_on[row.id] <= shut_down[row.id],
+                            units_on[row.units_on_id-1] - units_on[row.units_on_id] <=
+                            shut_down[row.shut_down_id],
                             base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
                         )
                     end
-                end for row in cons.indices
+                end for row in indices
             ],
         )
     end

--- a/src/constraints/start-up-and-shut-down-lower-bound.jl
+++ b/src/constraints/start-up-and-shut-down-lower-bound.jl
@@ -18,8 +18,6 @@ function add_start_up_and_shut_down_lower_bound_constraints!(
 
         indices = _append_variable_ids(connection, table_name, ["units_on", "start_up"])
 
-        print(indices)
-
         attach_constraint!(
             model,
             cons,

--- a/src/constraints/start-up-upper-bound.jl
+++ b/src/constraints/start-up-upper-bound.jl
@@ -17,7 +17,7 @@ function add_start_up_upper_bound_constraints!(
         start_up_vars = variables[:start_up].container,
         units_on_vars = variables[:units_on].container
 
-        indices = _append_units_on_and_start_up_variable_ids(connection, table_name)
+        indices = _append_variable_ids(connection, table_name, ["units_on", "start_up"])
 
         attach_constraint!(
             model,
@@ -32,29 +32,4 @@ function add_start_up_upper_bound_constraints!(
             ],
         )
     end
-end
-
-function _append_units_on_and_start_up_variable_ids(connection, table_name)
-    return DuckDB.query(
-        connection,
-        "SELECT
-            cons.*,
-            var_units_on.id as units_on_id,
-            var_start_up.id as start_up_id
-        FROM cons_$table_name AS cons
-        LEFT JOIN asset
-            ON cons.asset = asset.asset
-        LEFT JOIN var_units_on
-            ON var_units_on.asset = cons.asset
-            AND var_units_on.year = cons.year
-            AND var_units_on.rep_period = cons.rep_period
-            AND var_units_on.time_block_start = cons.time_block_start
-        LEFT JOIN var_start_up
-            ON var_start_up.asset = cons.asset
-            AND var_start_up.year = cons.year
-            AND var_start_up.rep_period = cons.rep_period
-            AND var_start_up.time_block_start = cons.time_block_start
-        ORDER BY cons.id
-        ",
-    )
 end

--- a/src/constraints/su-sd-eq-units-on-diff.jl
+++ b/src/constraints/su-sd-eq-units-on-diff.jl
@@ -13,9 +13,12 @@ function add_su_sd_eq_units_on_diff_constraints!(
     constraints,
 )
     let table_name = :su_sd_eq_units_on_diff, cons = constraints[:su_sd_eq_units_on_diff]
-        units_on = cons.expressions[:units_on]
-        start_up = cons.expressions[:start_up]
-        shut_down = cons.expressions[:shut_down]
+        units_on = variables[:units_on].container
+        start_up = variables[:start_up].container
+        shut_down = variables[:shut_down].container
+
+        indices =
+            _append_variable_ids(connection, table_name, ["units_on", "start_up", "shut_down"])
 
         attach_constraint!(
             model,
@@ -28,12 +31,12 @@ function add_su_sd_eq_units_on_diff_constraints!(
                     else
                         @constraint(
                             model,
-                            units_on[row.id] - units_on[row.id-1] ==
-                            start_up[row.id] - shut_down[row.id],
+                            units_on[row.units_on_id] - units_on[row.units_on_id-1] ==
+                            start_up[row.start_up_id] - shut_down[row.shut_down_id],
                             base_name = "$table_name[$(row.asset),$(row.year),$(row.rep_period),$(row.time_block_start):$(row.time_block_end)]"
                         )
                     end
-                end for row in cons.indices
+                end for row in indices
             ],
         )
     end

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -608,7 +608,6 @@ function add_expressions_to_constraints!(connection, variables, constraints)
         :su_ramping_tight,
         :sd_ramping_tight,
         :trajectory,
-        :su_sd_eq_units_on_diff,
         :su_ramp_vars_flow_diff,
         :sd_ramp_vars_flow_diff,
         :su_ramp_vars_flow_upper_bound,

--- a/src/model-preparation.jl
+++ b/src/model-preparation.jl
@@ -614,9 +614,6 @@ function add_expressions_to_constraints!(connection, variables, constraints)
         :su_ramp_vars_flow_upper_bound,
         :sd_ramp_vars_flow_upper_bound,
         :su_sd_ramp_vars_flow_with_high_uptime,
-        :su_sd_eq_units_on_diff,
-        :start_up_lower_bound,
-        :shut_down_lower_bound,
     )
         @timeit to "attach units_on expression to $table_name" attach_expression_on_constraints_grouping_variables!(
             connection,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -110,3 +110,42 @@ function read_trajectory(trajectory::String, target::Float64 = 0.0)
         return parse.(Int, split(trajectory, ","))
     end
 end
+
+"""
+    _append_variable_ids(
+        connection,
+        constraint_table_name,
+        variables_to_append,
+    )
+
+Create table containing all rows of the given constraint (`constraint_table_name`) and their matching variable ids of the variables in `variables_to_append`
+"""
+function _append_variable_ids(connection, constraint_table_name, variables_to_append)
+    query_string = "SELECT
+                       cons.*,
+                   "
+
+    for variable in variables_to_append
+        query_string = query_string * "\n" * "var_$variable.id as $(variable)_id,"
+    end
+
+    query_string = query_string * "\n" * "FROM cons_$constraint_table_name AS cons
+                                            LEFT JOIN asset
+                                            ON cons.asset = asset.asset"
+
+    for variable in variables_to_append
+        variable_table_name = "var_$variable"
+
+        variable_query = "LEFT JOIN $variable_table_name
+                             ON $variable_table_name.asset = cons.asset
+                             AND $variable_table_name.year = cons.year
+                             AND $variable_table_name.rep_period = cons.rep_period
+                             AND $variable_table_name.time_block_start = cons.time_block_start"
+
+        query_string = query_string * "\n" * variable_query
+    end
+
+    query_string = query_string * "\n" * "ORDER BY cons.id"
+
+    return DuckDB.query(connection, query_string)
+end


### PR DESCRIPTION
SU/SD logical constraints and minimum up/down time now use only SQL to fix the misalignment of UC variables issue. 

For SU/SD ramp with vars, I would leave it as-is because Tulipa also uses the expressions for their ramping. I think it is possible to do it just with SQL, but it’s too annoying.

SU/SD ramping without vars does not use expressions.

For trajectories, I’d leave it as-is.

For all the things I changed, I compared the new model.lp against the old model.lp. The old model.lp files had been manually verified.